### PR TITLE
Make this TypeScript code valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ interface IOxtz {
     string > ;
 }
 
-const 0xtz: IOxtz = {
+const _0xtz: IOxtz = {
     name: "0xtz",
     location: "Morocco, Rabat",
     work: "FullStack Developer",


### PR DESCRIPTION
Variable names cannot start with a number, so I put an underscore before the number to make this code valid.